### PR TITLE
Always show subtitles view on iOS

### DIFF
--- a/FullScreenTranslator/Views/ContentView.swift
+++ b/FullScreenTranslator/Views/ContentView.swift
@@ -6,9 +6,7 @@ import SwiftUI
     var translated: String?
 
     var body: some View {
-      if let text {
-        SubtitlesView(text: text, translated: translated)
-      }
+      SubtitlesView(text: text ?? "", translated: translated)
     }
   }
 #elseif canImport(AppKit)

--- a/FullScreenTranslator/Views/SubtitlesView.swift
+++ b/FullScreenTranslator/Views/SubtitlesView.swift
@@ -24,22 +24,20 @@ import SwiftUI
               .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
           }
 
-          if let translated {
-            VStack(spacing: 8) {
-              Text("Translation")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+          VStack(spacing: 8) {
+            Text("Translation")
+              .font(.caption)
+              .foregroundStyle(.secondary)
 
-              Text(translated)
-                .font(.system(.headline, weight: .semibold))
-                .frame(maxWidth: .infinity, alignment: .center)
-                .multilineTextAlignment(.center)
-                .textSelection(.enabled)
-                .padding()
-                .background(Color.blue.opacity(0.1))
-                .clipShape(RoundedRectangle(cornerRadius: 12))
-                .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
-            }
+            Text(translated ?? "")
+              .font(.system(.headline, weight: .semibold))
+              .frame(maxWidth: .infinity, alignment: .center)
+              .multilineTextAlignment(.center)
+              .textSelection(.enabled)
+              .padding()
+              .background(Color.blue.opacity(0.1))
+              .clipShape(RoundedRectangle(cornerRadius: 12))
+              .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
           }
         }
       }


### PR DESCRIPTION
## Summary
- Modified ContentView to always display SubtitlesView on iOS even when there is no content
- Removed conditional rendering in SubtitlesView to always show both original and translation sections with empty strings when no content is available

## Test plan
- Launch app on iOS
- Verify subtitles UI is visible immediately, even before speaking
- Check that both original and translation sections appear with proper styling

🤖 Generated with [Claude Code](https://claude.ai/code)