### PR TITLE
クラッシュの原因を修正

### DIFF
--- a/FullScreenTranslator/Helpers/SpeechRecognizer.swift
+++ b/FullScreenTranslator/Helpers/SpeechRecognizer.swift
@@ -105,9 +105,7 @@ protocol SpeechRecognizerProtocol: Observable {
     guard isAuthorized else {
       throw Errors.notAuthorized
     }
-    guard isRecognizing else {
-      throw Errors.notRecognizing
-    }
+    audioEngine.inputNode.removeTap(onBus: 0)
     audioEngine.stop()
     recognitionRequest?.endAudio()
     isRecognizing = false


### PR DESCRIPTION

# 問題1
audioEngine.inputNodeの生成と削除を繰り返しているが削除ができていないパターンがあったので、下記エラー発生している。
stopRecognitionで確実にremoveTapするように削除する

```
*** Terminating app due to uncaught exception 'com.apple.coreaudio.avfaudio', reason: 'required condition is false: nullptr == Tap()'
*** First throw call stack:
(0x1986a15ec 0x195c1d244 0x1987ee6e0 0x1b32db3e0 0x1b338a624 0x1b335ffa0 0x105931c70 0x105934014 0x105935690 0x105933e18 0x105933679 0x105935081 0x1059353f9 0x105935555 0x1a3fb2e39)
libc++abi: terminating due to uncaught exception of type NSException
```

# 問題2
- `error != nil || (result?.isFinal ?? false)` の時の処理で音声認識が停止状態にある場合があるので、
自動で停止されていてもさらに停止できるようにエラーにしないようにした
